### PR TITLE
add configurable furnace, crafting table and third-party mod support + configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,16 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+	// Mod Menu, to add the hook for a config screen
+	modImplementation "io.github.prospector:modmenu:${project.modmenu_version}"
+
+	modApi("me.shedaniel.cloth:config-2:${project.cloth_version}") {
+		exclude(group: "net.fabricmc.fabric-api")
+	}
+	modApi("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
+		exclude group: "net.fabricmc.fabric-api", module: "fabric-api"
+	}
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
+
+repositories {
+	maven { url "https://maven.shedaniel.me/" }
+}
+
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
@@ -18,17 +23,10 @@ dependencies {
 	// Mod Menu, to add the hook for a config screen
 	modImplementation "io.github.prospector:modmenu:${project.modmenu_version}"
 
-	modApi("me.shedaniel.cloth:config-2:${project.cloth_version}") {
+	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
-	include("me.shedaniel.cloth:config-2:${project.cloth_version}") {
-		exclude group: "net.fabricmc.fabric-api", module: "fabric-api"
-	}
-
-	modApi("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
-		exclude group: "net.fabricmc.fabric-api", module: "fabric-api"
-	}
-	include("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
+	include("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
 		exclude group: "net.fabricmc.fabric-api", module: "fabric-api"
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,14 @@ dependencies {
 	modApi("me.shedaniel.cloth:config-2:${project.cloth_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
+	include("me.shedaniel.cloth:config-2:${project.cloth_version}") {
+		exclude group: "net.fabricmc.fabric-api", module: "fabric-api"
+	}
+
 	modApi("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
+		exclude group: "net.fabricmc.fabric-api", module: "fabric-api"
+	}
+	include("me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}") {
 		exclude group: "net.fabricmc.fabric-api", module: "fabric-api"
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.16.5
-	yarn_mappings=1.16.5+build.4
-	loader_version=0.11.1
+	yarn_mappings=1.16.5+build.9
+	loader_version=0.11.5
 
 # Mod Properties
 	mod_version = 1.0.6
@@ -16,5 +16,4 @@ org.gradle.jvmargs=-Xmx1G
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric
 	fabric_version=0.30.0+1.16
 	modmenu_version=1.14.13+build.19
-	cloth_version=4.8.3
-	auto_config_version=3.3.1
+	cloth_version=4.11.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx1G
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric
 	fabric_version=0.30.0+1.16
+	modmenu_version=1.14.13+build.19
+	cloth_version=4.8.3
+	auto_config_version=3.3.1

--- a/src/main/java/com/umollu/inventorypause/InventoryPauseMod.java
+++ b/src/main/java/com/umollu/inventorypause/InventoryPauseMod.java
@@ -1,8 +1,8 @@
 package com.umollu.inventorypause;
 
 import com.umollu.inventorypause.utils.ModConfig;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 
 public class InventoryPauseMod implements ModInitializer {

--- a/src/main/java/com/umollu/inventorypause/InventoryPauseMod.java
+++ b/src/main/java/com/umollu/inventorypause/InventoryPauseMod.java
@@ -1,9 +1,16 @@
 package com.umollu.inventorypause;
 
+import com.umollu.inventorypause.utils.ModConfig;
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 
 public class InventoryPauseMod implements ModInitializer {
+	public static ModConfig MOD_CONFIG = new ModConfig();
+
 	@Override
 	public void onInitialize() {
+		AutoConfig.register(ModConfig.class, GsonConfigSerializer::new);
+		MOD_CONFIG = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
 	}
 }

--- a/src/main/java/com/umollu/inventorypause/mixin/HandledScreenMixin.java
+++ b/src/main/java/com/umollu/inventorypause/mixin/HandledScreenMixin.java
@@ -1,5 +1,8 @@
 package com.umollu.inventorypause.mixin;
 
+import com.umollu.inventorypause.utils.ModConfig;
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import net.minecraft.client.gui.screen.ingame.*;
 import net.minecraft.client.gui.screen.ingame.AbstractInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import org.spongepowered.asm.mixin.Mixin;
@@ -9,11 +12,32 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(HandledScreen.class)
 public class HandledScreenMixin {
+    private final ModConfig config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
+
     @Inject(method = "isPauseScreen", at = @At("HEAD"), cancellable = true)
     public void isPauseScreen(CallbackInfoReturnable cir) {
-        if((Object)this instanceof AbstractInventoryScreen) {
+
+        if(isInventory() || isFurnace() || isCraftingTable() || isShulkerBox()) {
             cir.setReturnValue(true);
             cir.cancel();
+        } else if(config.debug) {
+            System.out.println(this.getClass());
         }
+    }
+
+    private boolean isInventory() {
+        return config.pauseInventory && (Object)this instanceof AbstractInventoryScreen;
+    }
+
+    private boolean isFurnace() {
+        return config.pauseFurnace && (Object)this instanceof AbstractFurnaceScreen;
+    }
+
+    private boolean isCraftingTable() {
+        return config.pauseCraftingTable && (Object)this instanceof CraftingScreen;
+    }
+
+    private boolean isShulkerBox() {
+        return config.pauseShulkerBox && (Object)this instanceof ShulkerBoxScreen;
     }
 }

--- a/src/main/java/com/umollu/inventorypause/mixin/HandledScreenMixin.java
+++ b/src/main/java/com/umollu/inventorypause/mixin/HandledScreenMixin.java
@@ -1,9 +1,8 @@
 package com.umollu.inventorypause.mixin;
 
 import com.umollu.inventorypause.utils.ModConfig;
+import com.umollu.inventorypause.utils.ScreenHelper;
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import net.minecraft.client.gui.screen.ingame.*;
-import net.minecraft.client.gui.screen.ingame.AbstractInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,41 +14,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(HandledScreen.class)
 public class HandledScreenMixin {
     private static final Logger LOGGER = LogManager.getLogger("inventorypause");
-    private final ModConfig config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
+    private static final ModConfig config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
 
     @Inject(method = "isPauseScreen", at = @At("HEAD"), cancellable = true)
     public void isPauseScreen(CallbackInfoReturnable cir) {
-
-        if(isInventory() || isFurnace() || isCraftingTable() || isShulkerBox() || isCustomMenu()) {
+        if(ScreenHelper.isConfiguredScreen(this)) {
             cir.setReturnValue(true);
             cir.cancel();
         } else if(config.debug) {
             LOGGER.info(this.getClass().getName());
         }
-    }
-
-    private boolean isInventory() {
-        return config.pauseInventory && (Object)this instanceof AbstractInventoryScreen;
-    }
-
-    private boolean isFurnace() {
-        return config.pauseFurnace && (Object)this instanceof AbstractFurnaceScreen;
-    }
-
-    private boolean isCraftingTable() {
-        return config.pauseCraftingTable && (Object)this instanceof CraftingScreen;
-    }
-
-    private boolean isShulkerBox() {
-        return config.pauseShulkerBox && (Object)this instanceof ShulkerBoxScreen;
-    }
-
-    private boolean isCustomMenu() {
-        for (String s : config.customScreens) {
-            if(this.getClass().getName().equals(s)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/com/umollu/inventorypause/mixin/HandledScreenMixin.java
+++ b/src/main/java/com/umollu/inventorypause/mixin/HandledScreenMixin.java
@@ -2,7 +2,7 @@ package com.umollu.inventorypause.mixin;
 
 import com.umollu.inventorypause.utils.ModConfig;
 import com.umollu.inventorypause.utils.ScreenHelper;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/umollu/inventorypause/mixin/HandledScreenMixin.java
+++ b/src/main/java/com/umollu/inventorypause/mixin/HandledScreenMixin.java
@@ -5,6 +5,8 @@ import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
 import net.minecraft.client.gui.screen.ingame.*;
 import net.minecraft.client.gui.screen.ingame.AbstractInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,16 +14,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(HandledScreen.class)
 public class HandledScreenMixin {
+    private static final Logger LOGGER = LogManager.getLogger("inventorypause");
     private final ModConfig config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
 
     @Inject(method = "isPauseScreen", at = @At("HEAD"), cancellable = true)
     public void isPauseScreen(CallbackInfoReturnable cir) {
 
-        if(isInventory() || isFurnace() || isCraftingTable() || isShulkerBox()) {
+        if(isInventory() || isFurnace() || isCraftingTable() || isShulkerBox() || isCustomMenu()) {
             cir.setReturnValue(true);
             cir.cancel();
         } else if(config.debug) {
-            System.out.println(this.getClass());
+            LOGGER.info(this.getClass().getName());
         }
     }
 
@@ -39,5 +42,14 @@ public class HandledScreenMixin {
 
     private boolean isShulkerBox() {
         return config.pauseShulkerBox && (Object)this instanceof ShulkerBoxScreen;
+    }
+
+    private boolean isCustomMenu() {
+        for (String s : config.customScreens) {
+            if(this.getClass().getName().equals(s)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/umollu/inventorypause/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/umollu/inventorypause/mixin/MinecraftClientMixin.java
@@ -1,5 +1,6 @@
 package com.umollu.inventorypause.mixin;
 
+import com.umollu.inventorypause.utils.ScreenHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.AbstractInventoryScreen;
@@ -20,7 +21,7 @@ public abstract class MinecraftClientMixin {
 
     @Inject(at = @At("TAIL"), method = "openScreen")
     public void openScreen(Screen screen, CallbackInfo ci) {
-        if (screen instanceof AbstractInventoryScreen)
+        if (ScreenHelper.isConfiguredScreen(screen))
         {
             boolean canPauseGame = isIntegratedServerRunning() && !this.server.isRemote();
             if(canPauseGame) {

--- a/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
@@ -3,12 +3,16 @@ package com.umollu.inventorypause.utils;
 import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
 import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Config(name = "inventorypause")
 public class ModConfig implements ConfigData {
     public boolean pauseInventory = true;
     public boolean pauseFurnace = false;
     public boolean pauseCraftingTable = false;
     public boolean pauseShulkerBox = false;
+    public List<String> customScreens = new ArrayList<>();
 
     public boolean debug = true;
 }

--- a/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
@@ -14,5 +14,5 @@ public class ModConfig implements ConfigData {
     public boolean pauseShulkerBox = false;
     public List<String> customScreens = new ArrayList<>();
 
-    public boolean debug = true;
+    public boolean debug = false;
 }

--- a/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
@@ -3,7 +3,7 @@ package com.umollu.inventorypause.utils;
 import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
 import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
 
-@Config(name = "inventory-pause")
+@Config(name = "inventorypause")
 public class ModConfig implements ConfigData {
     public boolean pauseInventory = true;
     public boolean pauseFurnace = false;

--- a/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
@@ -1,0 +1,14 @@
+package com.umollu.inventorypause.utils;
+
+import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
+import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
+
+@Config(name = "inventory-pause")
+public class ModConfig implements ConfigData {
+    public boolean pauseInventory = true;
+    public boolean pauseFurnace = false;
+    public boolean pauseCraftingTable = false;
+    public boolean pauseShulkerBox = false;
+
+    public boolean debug = true;
+}

--- a/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
@@ -1,7 +1,7 @@
 package com.umollu.inventorypause.utils;
 
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ModConfig.java
@@ -8,11 +8,11 @@ import java.util.List;
 
 @Config(name = "inventorypause")
 public class ModConfig implements ConfigData {
-    public boolean pauseInventory = true;
-    public boolean pauseFurnace = false;
-    public boolean pauseCraftingTable = false;
-    public boolean pauseShulkerBox = false;
-    public List<String> customScreens = new ArrayList<>();
+    boolean pauseInventory = true;
+    boolean pauseFurnace = false;
+    boolean pauseCraftingTable = false;
+    boolean pauseShulkerBox = false;
+    List<String> customScreens = new ArrayList<>();
 
     public boolean debug = false;
 }

--- a/src/main/java/com/umollu/inventorypause/utils/ModMenuIntegration.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ModMenuIntegration.java
@@ -1,0 +1,16 @@
+package com.umollu.inventorypause.utils;
+
+import io.github.prospector.modmenu.api.ConfigScreenFactory;
+import io.github.prospector.modmenu.api.ModMenuApi;
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public class ModMenuIntegration implements ModMenuApi {
+
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> AutoConfig.getConfigScreen(ModConfig.class, parent).get();
+    }
+}

--- a/src/main/java/com/umollu/inventorypause/utils/ModMenuIntegration.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ModMenuIntegration.java
@@ -2,7 +2,7 @@ package com.umollu.inventorypause.utils;
 
 import io.github.prospector.modmenu.api.ConfigScreenFactory;
 import io.github.prospector.modmenu.api.ModMenuApi;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 

--- a/src/main/java/com/umollu/inventorypause/utils/ScreenHelper.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ScreenHelper.java
@@ -1,0 +1,40 @@
+package com.umollu.inventorypause.utils;
+
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import net.minecraft.client.gui.screen.ingame.AbstractFurnaceScreen;
+import net.minecraft.client.gui.screen.ingame.AbstractInventoryScreen;
+import net.minecraft.client.gui.screen.ingame.CraftingScreen;
+import net.minecraft.client.gui.screen.ingame.ShulkerBoxScreen;
+
+public class ScreenHelper {
+    private static final ModConfig config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
+
+    public static boolean isConfiguredScreen(Object screen) {
+        return isInventory(screen) || isFurnace(screen) || isCraftingTable(screen) || isShulkerBox(screen) || isCustomMenu(screen);
+    }
+
+    private static boolean isInventory(Object screen) {
+        return config.pauseInventory && screen instanceof AbstractInventoryScreen;
+    }
+
+    private static boolean isFurnace(Object screen) {
+        return config.pauseFurnace && screen instanceof AbstractFurnaceScreen;
+    }
+
+    private static boolean isCraftingTable(Object screen) {
+        return config.pauseCraftingTable && screen instanceof CraftingScreen;
+    }
+
+    private static boolean isShulkerBox(Object screen) {
+        return config.pauseShulkerBox && screen instanceof ShulkerBoxScreen;
+    }
+
+    private static boolean isCustomMenu(Object screen) {
+        for (String s : config.customScreens) {
+            if(screen.getClass().getName().equals(s)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/umollu/inventorypause/utils/ScreenHelper.java
+++ b/src/main/java/com/umollu/inventorypause/utils/ScreenHelper.java
@@ -1,6 +1,6 @@
 package com.umollu.inventorypause.utils;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.gui.screen.ingame.AbstractFurnaceScreen;
 import net.minecraft.client.gui.screen.ingame.AbstractInventoryScreen;
 import net.minecraft.client.gui.screen.ingame.CraftingScreen;

--- a/src/main/resources/assets/inventorypause/lang/en_us.json
+++ b/src/main/resources/assets/inventorypause/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "text.autoconfig.inventory-pause.option.title": "Inventory Pause Config",
+  "text.autoconfig.inventory-pause.option.pauseInventory": "Pause on Inventory",
+  "text.autoconfig.inventory-pause.option.pauseFurnace": "Pause on Furnace",
+  "text.autoconfig.inventory-pause.option.pauseCraftingTable": "Pause on Crafting Table",
+  "text.autoconfig.inventory-pause.option.pauseShulkerBox": "Pause on Shulker Box"
+}

--- a/src/main/resources/assets/inventorypause/lang/en_us.json
+++ b/src/main/resources/assets/inventorypause/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "text.autoconfig.inventorypause.option.title": "Inventory Pause Config",
+  "text.autoconfig.inventorypause.title": "Inventory Pause Config",
   "text.autoconfig.inventorypause.option.pauseInventory": "Pause on Inventory",
   "text.autoconfig.inventorypause.option.pauseFurnace": "Pause on Furnace",
   "text.autoconfig.inventorypause.option.pauseCraftingTable": "Pause on Crafting Table",

--- a/src/main/resources/assets/inventorypause/lang/en_us.json
+++ b/src/main/resources/assets/inventorypause/lang/en_us.json
@@ -1,7 +1,8 @@
 {
-  "text.autoconfig.inventory-pause.option.title": "Inventory Pause Config",
-  "text.autoconfig.inventory-pause.option.pauseInventory": "Pause on Inventory",
-  "text.autoconfig.inventory-pause.option.pauseFurnace": "Pause on Furnace",
-  "text.autoconfig.inventory-pause.option.pauseCraftingTable": "Pause on Crafting Table",
-  "text.autoconfig.inventory-pause.option.pauseShulkerBox": "Pause on Shulker Box"
+  "text.autoconfig.inventorypause.option.title": "Inventory Pause Config",
+  "text.autoconfig.inventorypause.option.pauseInventory": "Pause on Inventory",
+  "text.autoconfig.inventorypause.option.pauseFurnace": "Pause on Furnace",
+  "text.autoconfig.inventorypause.option.pauseCraftingTable": "Pause on Crafting Table",
+  "text.autoconfig.inventorypause.option.pauseShulkerBox": "Pause on Shulker Box",
+  "text.autoconfig.inventorypause.option.customScreens": "Custom mod class names"
 }

--- a/src/main/resources/assets/inventorypause/lang/en_us.json
+++ b/src/main/resources/assets/inventorypause/lang/en_us.json
@@ -4,5 +4,6 @@
   "text.autoconfig.inventorypause.option.pauseFurnace": "Pause on Furnace",
   "text.autoconfig.inventorypause.option.pauseCraftingTable": "Pause on Crafting Table",
   "text.autoconfig.inventorypause.option.pauseShulkerBox": "Pause on Shulker Box",
-  "text.autoconfig.inventorypause.option.customScreens": "Custom mod class names"
+  "text.autoconfig.inventorypause.option.customScreens": "Custom mod class names",
+  "text.autoconfig.inventorypause.option.debug": "Enable Debug Mode"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,6 +18,9 @@
   "entrypoints": {
     "main": [
       "com.umollu.inventorypause.InventoryPauseMod"
+    ],
+    "modmenu": [
+      "com.umollu.inventorypause.utils.ModMenuIntegration"
     ]
   },
   "mixins": [


### PR DESCRIPTION
Fixes #3. This isn't compatible with all third-party mods because some don't use the HandledScreen super class and implement Screen by themselves.

- adds support for furnaces, crafting tables and a limited set of third-party mods.
- adds a config screen with mod menu integration